### PR TITLE
Workaround for showToast

### DIFF
--- a/design/src/main/java/com/github/kr328/clash/design/Design.kt
+++ b/design/src/main/java/com/github/kr328/clash/design/Design.kt
@@ -14,7 +14,6 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.withContext
 
 abstract class Design<R>(val context: Context) :
   CoroutineScope by CoroutineScope(Dispatchers.Unconfined) {
@@ -30,16 +29,16 @@ abstract class Design<R>(val context: Context) :
     }
   }
 
-  suspend fun showToast(resId: Int, duration: ToastDuration, configure: Snackbar.() -> Unit = {}) {
+  fun showToast(resId: Int, duration: ToastDuration, configure: Snackbar.() -> Unit = {}) {
     return showToast(context.getString(resId), duration, configure)
   }
 
-  suspend fun showToast(
+  fun showToast(
     message: CharSequence,
     duration: ToastDuration,
     configure: Snackbar.() -> Unit = {},
   ) {
-    withContext(Dispatchers.Main) {
+    root.post {
       Snackbar.make(
           root,
           message,


### PR DESCRIPTION
```
java.lang.IllegalArgumentException: No suitable parent found from the given view. Please provide a valid view.
  at com.google.android.material.snackbar.Snackbar.makeInternal(Snackbar.java:232)
  at com.google.android.material.snackbar.Snackbar.make(Snackbar.java:170)
  at com.github.kr328.clash.design.Design$showToast$5.invokeSuspend(Design.kt:43)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
  at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
  at android.os.Handler.handleCallback(Handler.java:1095)
  at android.os.Handler.dispatchMessageImpl(Handler.java:135)
  at android.os.Handler.dispatchMessage(Handler.java:125)
  at android.os.Looper.loopOnce(Looper.java:269)
  at android.os.Looper.loop(Looper.java:367)
  at android.app.ActivityThread.main(ActivityThread.java:9333)
  at java.lang.reflect.Method.invoke(Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:566)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
  Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@8358e07, Dispatchers.Unconfined]
```

Refs #65.