### PR TITLE
Stop unregistering Broadcasts

### DIFF
--- a/app/src/main/kotlin/com/github/kr328/clash/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/kr328/clash/app/MainActivity.kt
@@ -42,7 +42,7 @@ import com.github.kr328.clash.common.util.uuid
 import com.github.kr328.clash.crash.CrashRoute
 import com.github.kr328.clash.crash.crashEntries
 import com.github.kr328.clash.glue.model.DarkMode
-import com.github.kr328.clash.glue.remote.StatusClient
+import com.github.kr328.clash.glue.remote.Remote
 import com.github.kr328.clash.glue.store.UiStore
 import com.github.kr328.clash.glue.util.mainIntent
 import com.github.kr328.clash.glue.util.startClashService
@@ -148,19 +148,19 @@ class MainActivity : ComponentActivity() {
   }
 
   private fun Intent.handleExternalQuickAction(): Boolean {
-    val clashRunning = StatusClient(this@MainActivity).currentProfile() != null
-
     return when (action) {
       Intents.ACTION_TOGGLE_CLASH -> {
-        if (clashRunning) stopClash() else startClash()
+        if (Remote.broadcasts.clashRunning) stopClash() else startClash()
         true
       }
       Intents.ACTION_START_CLASH -> {
-        if (!clashRunning) startClash() else toast(R.string.external_control_started)
+        if (!Remote.broadcasts.clashRunning) startClash()
+        else toast(R.string.external_control_started)
         true
       }
       Intents.ACTION_STOP_CLASH -> {
-        if (clashRunning) stopClash() else toast(R.string.external_control_stopped)
+        if (Remote.broadcasts.clashRunning) stopClash()
+        else toast(R.string.external_control_stopped)
         true
       }
       else -> false

--- a/app/src/main/kotlin/com/github/kr328/clash/app/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/kr328/clash/app/MainActivity.kt
@@ -42,7 +42,7 @@ import com.github.kr328.clash.common.util.uuid
 import com.github.kr328.clash.crash.CrashRoute
 import com.github.kr328.clash.crash.crashEntries
 import com.github.kr328.clash.glue.model.DarkMode
-import com.github.kr328.clash.glue.remote.Remote
+import com.github.kr328.clash.glue.remote.StatusClient
 import com.github.kr328.clash.glue.store.UiStore
 import com.github.kr328.clash.glue.util.mainIntent
 import com.github.kr328.clash.glue.util.startClashService
@@ -148,19 +148,19 @@ class MainActivity : ComponentActivity() {
   }
 
   private fun Intent.handleExternalQuickAction(): Boolean {
+    val clashRunning = StatusClient(this@MainActivity).currentProfile() != null
+
     return when (action) {
       Intents.ACTION_TOGGLE_CLASH -> {
-        if (Remote.broadcasts.clashRunning) stopClash() else startClash()
+        if (clashRunning) stopClash() else startClash()
         true
       }
       Intents.ACTION_START_CLASH -> {
-        if (!Remote.broadcasts.clashRunning) startClash()
-        else toast(R.string.external_control_started)
+        if (!clashRunning) startClash() else toast(R.string.external_control_started)
         true
       }
       Intents.ACTION_STOP_CLASH -> {
-        if (Remote.broadcasts.clashRunning) stopClash()
-        else toast(R.string.external_control_stopped)
+        if (clashRunning) stopClash() else toast(R.string.external_control_stopped)
         true
       }
       else -> false

--- a/glue/src/main/kotlin/com/github/kr328/clash/glue/remote/Broadcasts.kt
+++ b/glue/src/main/kotlin/com/github/kr328/clash/glue/remote/Broadcasts.kt
@@ -103,17 +103,4 @@ class Broadcasts(private val context: Application) {
       Log.w("Register global receiver: $e", e)
     }
   }
-
-  fun unregister() {
-    if (!registered) return
-
-    try {
-      context.unregisterReceiver(broadcastReceiver)
-      registered = false
-
-      clashRunning = false
-    } catch (e: Exception) {
-      Log.w("Unregister global receiver: $e", e)
-    }
-  }
 }

--- a/glue/src/main/kotlin/com/github/kr328/clash/glue/remote/Remote.kt
+++ b/glue/src/main/kotlin/com/github/kr328/clash/glue/remote/Remote.kt
@@ -28,7 +28,7 @@ object Remote {
     }
 
   fun launch() {
-    broadcasts.register()
+    Global.launch(Dispatchers.IO) { broadcasts.register() }
     ApplicationObserver.attach(application)
     ApplicationObserver.onVisibleChanged {
       if (it) {

--- a/glue/src/main/kotlin/com/github/kr328/clash/glue/remote/Remote.kt
+++ b/glue/src/main/kotlin/com/github/kr328/clash/glue/remote/Remote.kt
@@ -28,7 +28,7 @@ object Remote {
     }
 
   fun launch() {
-    Global.launch(Dispatchers.IO) { broadcasts.register() }
+    broadcasts.register()
     ApplicationObserver.attach(application)
     ApplicationObserver.onVisibleChanged {
       if (it) {

--- a/glue/src/main/kotlin/com/github/kr328/clash/glue/remote/Remote.kt
+++ b/glue/src/main/kotlin/com/github/kr328/clash/glue/remote/Remote.kt
@@ -28,17 +28,15 @@ object Remote {
     }
 
   fun launch() {
+    broadcasts.register()
     ApplicationObserver.attach(application)
-
     ApplicationObserver.onVisibleChanged {
       if (it) {
         Log.d("App becomes visible")
         service.bind()
-        broadcasts.register()
       } else {
         Log.d("App becomes invisible")
         service.unbind()
-        broadcasts.unregister()
       }
     }
 


### PR DESCRIPTION
`MainActivity#handleExternalQuickAction` is not working in `MainActivity#onCreate` but `onNewIntent`, cause `clashRunning` is alway `false` before the Activity is visible.