### PR TITLE
Bind settings persistence to lifecycle

### DIFF
--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/AccessControlScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/AccessControlScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.graphics.drawable.toDrawable
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.kr328.clash.common.R as CommonR
@@ -77,9 +78,13 @@ internal fun AccessControlScreen(
   modifier: Modifier = Modifier,
   viewModel: AccessControlViewModel = viewModel(),
 ) {
+  val lifecycleOwner = LocalLifecycleOwner.current
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-  DisposableEffect(viewModel) { onDispose { viewModel.persistSelection() } }
+  DisposableEffect(lifecycleOwner, viewModel) {
+    lifecycleOwner.lifecycle.addObserver(viewModel)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(viewModel) }
+  }
 
   AccessControlContent(
     apps = uiState.apps,

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/MetaFeatureSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/MetaFeatureSettingsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.PreviewWrapper
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavKey
@@ -58,12 +59,16 @@ internal fun MetaFeatureSettingsScreen(
   viewModel: MetaFeatureSettingsViewModel = viewModel(),
   onResetCompleted: () -> Unit,
 ) {
+  val lifecycleOwner = LocalLifecycleOwner.current
   val backStack = rememberNavBackStackBuilder { add(MetaFeatureSettingsRoute.Main) }
   var currentEditableTextListOnApply by remember {
     mutableStateOf<((List<String>?) -> Unit)?>(null)
   }
 
-  DisposableEffect(viewModel) { onDispose { viewModel.persistOverride() } }
+  DisposableEffect(lifecycleOwner, viewModel) {
+    lifecycleOwner.lifecycle.addObserver(viewModel)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(viewModel) }
+  }
 
   TabbyNavDisplay(
     backStack = backStack,

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/OverrideSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/OverrideSettingsScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.PreviewWrapper
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavKey
@@ -67,6 +68,7 @@ internal fun OverrideSettingsScreen(
   viewModel: OverrideSettingsViewModel = viewModel(),
   onResetCompleted: () -> Unit,
 ) {
+  val lifecycleOwner = LocalLifecycleOwner.current
   val backStack = rememberNavBackStackBuilder { add(OverrideSettingsRoute.Main) }
   var currentEditableTextMapOnApply by remember {
     mutableStateOf<((Map<String, String>?) -> Unit)?>(null)
@@ -75,7 +77,10 @@ internal fun OverrideSettingsScreen(
     mutableStateOf<((List<String>?) -> Unit)?>(null)
   }
 
-  DisposableEffect(viewModel) { onDispose { viewModel.persistOverride() } }
+  DisposableEffect(lifecycleOwner, viewModel) {
+    lifecycleOwner.lifecycle.addObserver(viewModel)
+    onDispose { lifecycleOwner.lifecycle.removeObserver(viewModel) }
+  }
 
   TabbyNavDisplay(
     backStack = backStack,

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/AccessControlViewModel.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/AccessControlViewModel.kt
@@ -12,8 +12,9 @@ import android.graphics.drawable.Drawable
 import android.os.Process
 import androidx.core.content.getSystemService
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
-import com.github.kr328.clash.common.Global
 import com.github.kr328.clash.glue.model.AppInfo
 import com.github.kr328.clash.glue.remote.Remote
 import com.github.kr328.clash.glue.store.UiStore
@@ -33,7 +34,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 
 internal class AccessControlViewModel(app: Application) :
-  AndroidViewModel(app), AccessControlActions {
+  AndroidViewModel(app), AccessControlActions, DefaultLifecycleObserver {
   private val appContext = app
   private val uiStore = UiStore(app)
   private val serviceStore = ServiceStore(app)
@@ -61,9 +62,8 @@ internal class AccessControlViewModel(app: Application) :
     }
   }
 
-  fun persistSelection() {
-    // Intended to use non-viewModel scope as we need the action to be called on disposed.
-    Global.launch {
+  override fun onStop(owner: LifecycleOwner) {
+    viewModelScope.launch {
       val selected = uiState.value.selected
       val persistedSelection = serviceStore.accessControlPackages
       val changed = selected != persistedSelection

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/AccessControlViewModel.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/AccessControlViewModel.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
+import com.github.kr328.clash.common.Global
 import com.github.kr328.clash.glue.model.AppInfo
 import com.github.kr328.clash.glue.remote.Remote
 import com.github.kr328.clash.glue.store.UiStore
@@ -63,7 +64,8 @@ internal class AccessControlViewModel(app: Application) :
   }
 
   override fun onStop(owner: LifecycleOwner) {
-    viewModelScope.launch {
+    // Intended to use non-viewModel scope as we need the action to be called on disposed.
+    Global.launch {
       val selected = uiState.value.selected
       val persistedSelection = serviceStore.accessControlPackages
       val changed = selected != persistedSelection

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/MetaFeatureSettingsViewModel.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/MetaFeatureSettingsViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
+import com.github.kr328.clash.common.Global
 import com.github.kr328.clash.common.log.Log
 import com.github.kr328.clash.core.Clash
 import com.github.kr328.clash.core.model.ConfigurationOverride
@@ -39,7 +40,8 @@ internal class MetaFeatureSettingsViewModel(app: Application) :
   }
 
   override fun onStop(owner: LifecycleOwner) {
-    viewModelScope.launch {
+    // Intended to use non-viewModel scope as we need the action to be called on disposed.
+    Global.launch {
       withClash {
         if (skipPersist) clearOverride(Clash.OverrideSlot.Persist)
         else patchOverride(Clash.OverrideSlot.Persist, configuration.value)

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/MetaFeatureSettingsViewModel.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/MetaFeatureSettingsViewModel.kt
@@ -5,8 +5,9 @@ import android.database.Cursor
 import android.net.Uri
 import android.provider.OpenableColumns
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
-import com.github.kr328.clash.common.Global
 import com.github.kr328.clash.common.log.Log
 import com.github.kr328.clash.core.Clash
 import com.github.kr328.clash.core.model.ConfigurationOverride
@@ -20,7 +21,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 internal class MetaFeatureSettingsViewModel(app: Application) :
-  AndroidViewModel(app), MetaFeatureSettingsActions {
+  AndroidViewModel(app), MetaFeatureSettingsActions, DefaultLifecycleObserver {
   private val appContext = app
   private val validDatabaseExtensions = listOf(".metadb", ".db", ".dat", ".mmdb")
   @Volatile private var skipPersist = false
@@ -37,18 +38,17 @@ internal class MetaFeatureSettingsViewModel(app: Application) :
     }
   }
 
-  fun persistOverride() {
-    // Intended to use non-viewModel scope as we need the action to be called on disposed.
-    Global.launch {
-      if (skipPersist) return@launch
-      withClash { patchOverride(Clash.OverrideSlot.Persist, configuration.value) }
+  override fun onStop(owner: LifecycleOwner) {
+    viewModelScope.launch {
+      withClash {
+        if (skipPersist) clearOverride(Clash.OverrideSlot.Persist)
+        else patchOverride(Clash.OverrideSlot.Persist, configuration.value)
+      }
     }
   }
 
   fun resetOverride() {
     skipPersist = true
-    // Intended to use non-viewModel scope as the action might be called on disposed.
-    Global.launch { withClash { clearOverride(Clash.OverrideSlot.Persist) } }
   }
 
   fun importGeoFile(uri: Uri?, importType: ImportType) {

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/OverrideSettingsViewModel.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/OverrideSettingsViewModel.kt
@@ -2,8 +2,9 @@ package com.github.kr328.clash.settings.vm
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
-import com.github.kr328.clash.common.Global
 import com.github.kr328.clash.core.Clash
 import com.github.kr328.clash.core.model.ConfigurationOverride
 import com.github.kr328.clash.core.model.LogMessage
@@ -16,7 +17,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 internal class OverrideSettingsViewModel(app: Application) :
-  AndroidViewModel(app), OverrideSettingsActions {
+  AndroidViewModel(app), OverrideSettingsActions, DefaultLifecycleObserver {
   @Volatile private var skipPersist = false
 
   val configuration: StateFlow<ConfigurationOverride>
@@ -28,18 +29,17 @@ internal class OverrideSettingsViewModel(app: Application) :
     }
   }
 
-  fun persistOverride() {
-    // Intended to use non-viewModel scope as we need the action to be called on disposed.
-    Global.launch {
-      if (skipPersist) return@launch
-      withClash { patchOverride(Clash.OverrideSlot.Persist, configuration.value) }
+  override fun onStop(owner: LifecycleOwner) {
+    viewModelScope.launch {
+      withClash {
+        if (skipPersist) clearOverride(Clash.OverrideSlot.Persist)
+        else patchOverride(Clash.OverrideSlot.Persist, configuration.value)
+      }
     }
   }
 
   fun resetOverride() {
     skipPersist = true
-    // Intended to use non-viewModel scope as the action might be called on disposed.
-    Global.launch { withClash { clearOverride(Clash.OverrideSlot.Persist) } }
   }
 
   override fun updateHttpPort(value: Int?) = configuration.update { it.copy(httpPort = value) }

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/OverrideSettingsViewModel.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/OverrideSettingsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewModelScope
+import com.github.kr328.clash.common.Global
 import com.github.kr328.clash.core.Clash
 import com.github.kr328.clash.core.model.ConfigurationOverride
 import com.github.kr328.clash.core.model.LogMessage
@@ -30,7 +31,8 @@ internal class OverrideSettingsViewModel(app: Application) :
   }
 
   override fun onStop(owner: LifecycleOwner) {
-    viewModelScope.launch {
+    // Intended to use non-viewModel scope as we need the action to be called on disposed.
+    Global.launch {
       withClash {
         if (skipPersist) clearOverride(Clash.OverrideSlot.Persist)
         else patchOverride(Clash.OverrideSlot.Persist, configuration.value)


### PR DESCRIPTION
Replace dispose-triggered Global scope writes with lifecycle observer callbacks and ViewModel-scoped persistence so settings are saved from onStop without escaping the screen lifecycle.

Refs #226.