### PR TITLE
Support reordering editable lists

### DIFF
--- a/common/src/main/res/values-ja-rJP/strings.xml
+++ b/common/src/main/res/values-ja-rJP/strings.xml
@@ -37,6 +37,7 @@
   <string name="receive_broadcasts_of_tabby">Tabby サービスのブロードキャストを受信</string>
   <string name="receive_tabby_broadcasts">Tabby ブロードキャストを受信</string>
   <string name="recently">直近</string>
+  <string name="reorder">並び替え</string>
   <string name="reset">リセット</string>
   <string name="rule">ルール</string>
   <string name="rule_mode">ルールモード</string>

--- a/common/src/main/res/values-ko-rKR/strings.xml
+++ b/common/src/main/res/values-ko-rKR/strings.xml
@@ -37,6 +37,7 @@
   <string name="receive_broadcasts_of_tabby">Tabby 서비스 브로드캐스트 수신</string>
   <string name="receive_tabby_broadcasts">Tabby 브로드캐스트 수신</string>
   <string name="recently">최근</string>
+  <string name="reorder">순서 변경</string>
   <string name="reset">재설정</string>
   <string name="rule">규칙</string>
   <string name="rule_mode">규칙</string>

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -37,6 +37,7 @@
   <string name="receive_broadcasts_of_tabby">Получать уведомления от сервисов Tabby</string>
   <string name="receive_tabby_broadcasts">Получать уведомления Tabby</string>
   <string name="recently">Недавно</string>
+  <string name="reorder">Изменить порядок</string>
   <string name="reset">Сброс</string>
   <string name="rule">Правило</string>
   <string name="rule_mode">Режим правил</string>

--- a/common/src/main/res/values-vi/strings.xml
+++ b/common/src/main/res/values-vi/strings.xml
@@ -37,6 +37,7 @@
   <string name="receive_broadcasts_of_tabby">Nhận thông báo của dịch vụ Tabby</string>
   <string name="receive_tabby_broadcasts">Nhận thông báo Tabby</string>
   <string name="recently">Vừa xong</string>
+  <string name="reorder">Sắp xếp lại</string>
   <string name="reset">Đặt lại</string>
   <string name="rule">Quy tắc</string>
   <string name="rule_mode">Chế độ quy tắc</string>

--- a/common/src/main/res/values-zh-rHK/strings.xml
+++ b/common/src/main/res/values-zh-rHK/strings.xml
@@ -37,6 +37,7 @@
   <string name="receive_broadcasts_of_tabby">接收 Tabby 服務的廣播</string>
   <string name="receive_tabby_broadcasts">接收 Tabby 廣播</string>
   <string name="recently">近期</string>
+  <string name="reorder">重新排序</string>
   <string name="reset">重置</string>
   <string name="rule">規則</string>
   <string name="rule_mode">規則模式</string>

--- a/common/src/main/res/values-zh-rTW/strings.xml
+++ b/common/src/main/res/values-zh-rTW/strings.xml
@@ -37,6 +37,7 @@
   <string name="receive_broadcasts_of_tabby">接收 Tabby 服務的廣播</string>
   <string name="receive_tabby_broadcasts">接收 Tabby 廣播</string>
   <string name="recently">最近</string>
+  <string name="reorder">重新排序</string>
   <string name="reset">重設</string>
   <string name="rule">規則</string>
   <string name="rule_mode">規則模式</string>

--- a/common/src/main/res/values-zh/strings.xml
+++ b/common/src/main/res/values-zh/strings.xml
@@ -37,6 +37,7 @@
   <string name="receive_broadcasts_of_tabby">接收 Tabby 服务的广播</string>
   <string name="receive_tabby_broadcasts">接收 Tabby 广播</string>
   <string name="recently">近期</string>
+  <string name="reorder">重新排序</string>
   <string name="reset">重置</string>
   <string name="rule">规则</string>
   <string name="rule_mode">规则模式</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
   <string name="receive_broadcasts_of_tabby">Receive broadcasts of Tabby services</string>
   <string name="receive_tabby_broadcasts">Receive Tabby Broadcasts</string>
   <string name="recently">Recently</string>
+  <string name="reorder">Reorder</string>
   <string name="reset">Reset</string>
   <string name="rule">Rule</string>
   <string name="rule_mode">Rule Mode</string>

--- a/core/src/main/kotlin/com/github/kr328/clash/core/model/ConfigurationOverride.kt
+++ b/core/src/main/kotlin/com/github/kr328/clash/core/model/ConfigurationOverride.kt
@@ -1,6 +1,7 @@
 package com.github.kr328.clash.core.model
 
 import android.os.Parcelable
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -34,7 +35,7 @@ data class ConfigurationOverride(
   @SerialName("clash-for-android") val app: App = App(),
   val sniffer: Sniffer = Sniffer(),
   @SerialName("geox-url") val geoxurl: GeoXUrl = GeoXUrl(),
-  @Transient val revision: Int = 0,
+  @IgnoredOnParcel @Transient val revision: Int = 0,
 ) : Parcelable {
   @Serializable
   @Parcelize

--- a/core/src/main/kotlin/com/github/kr328/clash/core/model/ConfigurationOverride.kt
+++ b/core/src/main/kotlin/com/github/kr328/clash/core/model/ConfigurationOverride.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 @Parcelize
 @Serializable
@@ -33,6 +34,7 @@ data class ConfigurationOverride(
   @SerialName("clash-for-android") val app: App = App(),
   val sniffer: Sniffer = Sniffer(),
   @SerialName("geox-url") val geoxurl: GeoXUrl = GeoXUrl(),
+  @Transient val revision: Int = 0,
 ) : Parcelable {
   @Serializable
   @Parcelize

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ koin-core = { module = "io.insert-koin:koin-core" }
 koin-android = { module = "io.insert-koin:koin-android" }
 
 composePreference = "me.zhanghai.compose.preference:preference:2.2.0"
+reorderable = "sh.calvin.reorderable:reorderable:2.4.3"
 
 # Dummy to get renovate updates, the version is used in rootProject build.gradle with spotless.
 ktfmt = "com.facebook:ktfmt:0.62"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ koin-core = { module = "io.insert-koin:koin-core" }
 koin-android = { module = "io.insert-koin:koin-android" }
 
 composePreference = "me.zhanghai.compose.preference:preference:2.2.0"
-reorderable = "sh.calvin.reorderable:reorderable:2.4.3"
+reorderable = "sh.calvin.reorderable:reorderable:3.1.0"
 
 # Dummy to get renovate updates, the version is used in rootProject build.gradle with spotless.
 ktfmt = "com.facebook:ktfmt:0.62"

--- a/ui/settings/build.gradle.kts
+++ b/ui/settings/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
   implementation(projects.ui)
 
   implementation(libs.composePreference)
+  implementation(libs.reorderable)
 
   implementation(platform(libs.koin.bom))
   implementation(libs.koin.core)

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextListScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextListScreen.kt
@@ -8,7 +8,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -37,11 +38,14 @@ import com.github.kr328.clash.common.R as CommonR
 import com.github.kr328.clash.settings.R
 import com.github.kr328.clash.ui.component.TabbyScaffold
 import com.github.kr328.clash.ui.icon.BaselineAdd
+import com.github.kr328.clash.ui.icon.BaselineDragHandle
 import com.github.kr328.clash.ui.icon.OutlineDelete
 import com.github.kr328.clash.ui.icon.TabbyIcons
 import com.github.kr328.clash.ui.theme.PreviewTabby
 import com.github.kr328.clash.ui.theme.TabbyThemeWrapper
 import kotlinx.serialization.Serializable
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
 
 @Serializable
 internal data class EditableTextList(val title: Int, val initialValues: List<String>?) : NavKey
@@ -67,8 +71,20 @@ private fun EditableTextListScreen(
   onDismiss: () -> Unit,
   onApply: (List<String>?) -> Unit,
 ) {
-  val values = remember(initialValues) { initialValues.orEmpty().toMutableStateList() }
+  val nextId = remember { longArrayOf(initialValues?.size?.toLong() ?: 0L) }
+  val values =
+    remember(initialValues) {
+      initialValues
+        .orEmpty()
+        .mapIndexed { index, value -> index.toLong() to value }
+        .toMutableStateList()
+    }
   var showAddDialog by remember { mutableStateOf(false) }
+  val lazyListState = rememberLazyListState()
+  val reorderableLazyListState =
+    rememberReorderableLazyListState(lazyListState) { from, to ->
+      values.apply { add(to.index, removeAt(from.index)) }
+    }
 
   TabbyScaffold(
     title = stringResource(title),
@@ -86,20 +102,29 @@ private fun EditableTextListScreen(
       if (values.isEmpty()) {
         EmptyEditorContent(Modifier.weight(1f))
       } else {
-        LazyColumn(modifier = Modifier.weight(1f)) {
-          itemsIndexed(values) { index, value ->
-            ListItem(
-              headlineContent = { Text(value) },
-              trailingContent = {
-                IconButton(onClick = { values.removeAt(index) }) {
+        LazyColumn(state = lazyListState, modifier = Modifier.weight(1f)) {
+          items(values, key = { it.first }) { item ->
+            ReorderableItem(reorderableLazyListState, key = item.first) { _ ->
+              ListItem(
+                headlineContent = { Text(item.second) },
+                leadingContent = {
                   Icon(
-                    imageVector = TabbyIcons.OutlineDelete,
-                    contentDescription = stringResource(CommonR.string.delete),
+                    imageVector = TabbyIcons.BaselineDragHandle,
+                    contentDescription = stringResource(CommonR.string.reorder),
+                    modifier = Modifier.draggableHandle(),
                   )
-                }
-              },
-            )
-            HorizontalDivider()
+                },
+                trailingContent = {
+                  IconButton(onClick = { values.remove(item) }) {
+                    Icon(
+                      imageVector = TabbyIcons.OutlineDelete,
+                      contentDescription = stringResource(CommonR.string.delete),
+                    )
+                  }
+                },
+              )
+              HorizontalDivider()
+            }
           }
         }
       }
@@ -110,7 +135,7 @@ private fun EditableTextListScreen(
       ) {
         TextButton(onClick = { onApply(null) }) { Text(stringResource(CommonR.string.reset)) }
         TextButton(onClick = onDismiss) { Text(stringResource(CommonR.string.cancel)) }
-        TextButton(onClick = { onApply(values.toList()) }) {
+        TextButton(onClick = { onApply(values.map { it.second }) }) {
           Text(stringResource(CommonR.string.ok))
         }
       }
@@ -123,7 +148,7 @@ private fun EditableTextListScreen(
       onDismiss = { showAddDialog = false },
       onConfirm = { newValue ->
         if (newValue.isNotBlank()) {
-          values.add(newValue)
+          values.add(nextId[0]++ to newValue)
         }
         showAddDialog = false
       },

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextListScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextListScreen.kt
@@ -71,14 +71,7 @@ private fun EditableTextListScreen(
   onDismiss: () -> Unit,
   onApply: (List<String>?) -> Unit,
 ) {
-  val nextId = remember { longArrayOf(initialValues?.size?.toLong() ?: 0L) }
-  val values =
-    remember(initialValues) {
-      initialValues
-        .orEmpty()
-        .mapIndexed { index, value -> index.toLong() to value }
-        .toMutableStateList()
-    }
+  val values = remember(initialValues) { initialValues.orEmpty().distinct().toMutableStateList() }
   var showAddDialog by remember { mutableStateOf(false) }
   val lazyListState = rememberLazyListState()
   val reorderableLazyListState =
@@ -103,10 +96,10 @@ private fun EditableTextListScreen(
         EmptyEditorContent(Modifier.weight(1f))
       } else {
         LazyColumn(state = lazyListState, modifier = Modifier.weight(1f)) {
-          items(values, key = { it.first }) { item ->
-            ReorderableItem(reorderableLazyListState, key = item.first) { _ ->
+          items(values, key = { it }) { item ->
+            ReorderableItem(reorderableLazyListState, key = item) { _ ->
               ListItem(
-                headlineContent = { Text(item.second) },
+                headlineContent = { Text(item) },
                 leadingContent = {
                   Icon(
                     imageVector = TabbyIcons.BaselineDragHandle,
@@ -135,7 +128,7 @@ private fun EditableTextListScreen(
       ) {
         TextButton(onClick = { onApply(null) }) { Text(stringResource(CommonR.string.reset)) }
         TextButton(onClick = onDismiss) { Text(stringResource(CommonR.string.cancel)) }
-        TextButton(onClick = { onApply(values.map { it.second }) }) {
+        TextButton(onClick = { onApply(values.toList()) }) {
           Text(stringResource(CommonR.string.ok))
         }
       }
@@ -147,8 +140,8 @@ private fun EditableTextListScreen(
       title = title,
       onDismiss = { showAddDialog = false },
       onConfirm = { newValue ->
-        if (newValue.isNotBlank()) {
-          values.add(nextId[0]++ to newValue)
+        if (newValue.isNotBlank() && newValue !in values) {
+          values.add(newValue)
         }
         showAddDialog = false
       },

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextMapScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextMapScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -37,11 +38,14 @@ import com.github.kr328.clash.common.R as CommonR
 import com.github.kr328.clash.settings.R
 import com.github.kr328.clash.ui.component.TabbyScaffold
 import com.github.kr328.clash.ui.icon.BaselineAdd
+import com.github.kr328.clash.ui.icon.BaselineDragHandle
 import com.github.kr328.clash.ui.icon.OutlineDelete
 import com.github.kr328.clash.ui.icon.TabbyIcons
 import com.github.kr328.clash.ui.theme.PreviewTabby
 import com.github.kr328.clash.ui.theme.TabbyThemeWrapper
 import kotlinx.serialization.Serializable
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
 
 @Serializable
 internal data class EditableTextMap(val title: Int, val initialValues: Map<String, String>?) :
@@ -73,6 +77,11 @@ private fun EditableTextMapScreen(
       initialValues?.entries.orEmpty().map { it.toPair() }.toMutableStateList()
     }
   var showAddDialog by remember { mutableStateOf(false) }
+  val lazyListState = rememberLazyListState()
+  val reorderableLazyListState =
+    rememberReorderableLazyListState(lazyListState) { from, to ->
+      values.apply { add(to.index, removeAt(from.index)) }
+    }
 
   TabbyScaffold(
     title = stringResource(title),
@@ -90,22 +99,31 @@ private fun EditableTextMapScreen(
       if (values.isEmpty()) {
         EmptyEditorContent(Modifier.weight(1f))
       } else {
-        LazyColumn(modifier = Modifier.weight(1f)) {
+        LazyColumn(state = lazyListState, modifier = Modifier.weight(1f)) {
           items(items = values, key = { it.first }) { entry ->
             val (key, value) = entry
-            ListItem(
-              headlineContent = { Text(key) },
-              supportingContent = { Text(value) },
-              trailingContent = {
-                IconButton(onClick = { values.remove(entry) }) {
+            ReorderableItem(reorderableLazyListState, key = key) { _ ->
+              ListItem(
+                headlineContent = { Text(key) },
+                supportingContent = { Text(value) },
+                leadingContent = {
                   Icon(
-                    imageVector = TabbyIcons.OutlineDelete,
-                    contentDescription = stringResource(CommonR.string.delete),
+                    imageVector = TabbyIcons.BaselineDragHandle,
+                    contentDescription = stringResource(CommonR.string.reorder),
+                    modifier = Modifier.draggableHandle(),
                   )
-                }
-              },
-            )
-            HorizontalDivider()
+                },
+                trailingContent = {
+                  IconButton(onClick = { values.remove(entry) }) {
+                    Icon(
+                      imageVector = TabbyIcons.OutlineDelete,
+                      contentDescription = stringResource(CommonR.string.delete),
+                    )
+                  }
+                },
+              )
+              HorizontalDivider()
+            }
           }
         }
       }

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextSetScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextSetScreen.kt
@@ -71,7 +71,7 @@ private fun EditableTextSetScreen(
   onDismiss: () -> Unit,
   onApply: (Set<String>?) -> Unit,
 ) {
-  val values = remember(initialValues) { initialValues.orEmpty().distinct().toMutableStateList() }
+  val values = remember(initialValues) { initialValues.orEmpty().toMutableStateList() }
   var showAddDialog by remember { mutableStateOf(false) }
   val lazyListState = rememberLazyListState()
   val reorderableLazyListState =

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextSetScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextSetScreen.kt
@@ -96,10 +96,10 @@ private fun EditableTextSetScreen(
         EmptyEditorContent(Modifier.weight(1f))
       } else {
         LazyColumn(state = lazyListState, modifier = Modifier.weight(1f)) {
-          items(values, key = { it }) { item ->
-            ReorderableItem(reorderableLazyListState, key = item) { _ ->
+          items(items = values, key = { it }) { value ->
+            ReorderableItem(reorderableLazyListState, key = value) { _ ->
               ListItem(
-                headlineContent = { Text(item) },
+                headlineContent = { Text(value) },
                 leadingContent = {
                   Icon(
                     imageVector = TabbyIcons.BaselineDragHandle,
@@ -108,7 +108,7 @@ private fun EditableTextSetScreen(
                   )
                 },
                 trailingContent = {
-                  IconButton(onClick = { values.remove(item) }) {
+                  IconButton(onClick = { values.remove(value) }) {
                     Icon(
                       imageVector = TabbyIcons.OutlineDelete,
                       contentDescription = stringResource(CommonR.string.delete),

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/OverrideSettingsViewModel.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/vm/OverrideSettingsViewModel.kt
@@ -93,7 +93,11 @@ internal class OverrideSettingsViewModel(app: Application) :
   }
 
   override fun updateHosts(value: Map<String, String>?) = configuration.update {
-    it.copy(hosts = value)
+    it.copy(
+      hosts = value,
+      // Force a new state emission when only map iteration order changes after reordering.
+      revision = it.revision + 1,
+    )
   }
 
   override fun updateDnsEnable(value: Boolean?) = configuration.update {
@@ -163,6 +167,7 @@ internal class OverrideSettingsViewModel(app: Application) :
   }
 
   override fun updateDnsNameserverPolicy(value: Map<String, String>?) = configuration.update {
-    it.copy(dns = it.dns.copy(nameserverPolicy = value))
+    // Force a new state emission when only map iteration order changes after reordering.
+    it.copy(dns = it.dns.copy(nameserverPolicy = value), revision = it.revision + 1)
   }
 }

--- a/ui/src/main/kotlin/com/github/kr328/clash/ui/icon/BaselineDragHandle.kt
+++ b/ui/src/main/kotlin/com/github/kr328/clash/ui/icon/BaselineDragHandle.kt
@@ -1,0 +1,44 @@
+package com.github.kr328.clash.ui.icon
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+@Suppress("UnusedReceiverParameter")
+val TabbyIcons.BaselineDragHandle: ImageVector
+  get() {
+    if (_BaselineDragHandle != null) {
+      return _BaselineDragHandle!!
+    }
+    _BaselineDragHandle =
+      ImageVector.Builder(
+          name = "BaselineDragHandle",
+          defaultWidth = 24.dp,
+          defaultHeight = 24.dp,
+          viewportWidth = 24f,
+          viewportHeight = 24f,
+        )
+        .apply {
+          path(fill = SolidColor(Color.White)) {
+            moveTo(20f, 9f)
+            horizontalLineTo(4f)
+            verticalLineToRelative(2f)
+            horizontalLineToRelative(16f)
+            verticalLineTo(9f)
+            close()
+            moveTo(4f, 15f)
+            horizontalLineToRelative(16f)
+            verticalLineToRelative(-2f)
+            horizontalLineTo(4f)
+            verticalLineToRelative(2f)
+            close()
+          }
+        }
+        .build()
+
+    return _BaselineDragHandle!!
+  }
+
+@Suppress("ObjectPropertyName") private var _BaselineDragHandle: ImageVector? = null


### PR DESCRIPTION
## What

Adds a drag handle to each list item in `EditableTextListScreen` and `EditableTextMapScreen`, allowing users to reorder entries by dragging.

## Changes

- **`gradle/libs.versions.toml`** / **`ui/settings/build.gradle.kts`**: add `sh.calvin.reorderable:reorderable:2.4.3` dependency
- **`ui/src/.../icon/BaselineDragHandle.kt`** *(new)*: drag handle vector icon (two horizontal bars)
- **`common/src/main/res/values/strings.xml`**: add `reorder` string for accessibility content description
- **`EditableTextListScreen.kt`**: wrap items in `ReorderableItem`, add `rememberReorderableLazyListState` for drag-to-reorder; items keyed by stable `Long` ID to handle duplicate string values safely
- **`EditableTextMapScreen.kt`**: same drag handle treatment; map keys serve as natural stable Compose keys

## How it works

The drag handle icon is placed as `leadingContent` in each `ListItem`. Users long-press and drag the handle to reorder; the updated order is committed when OK is tapped.
