### PR TITLE
Refactor EditableTextList to use Set

### DIFF
--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextListScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextListScreen.kt
@@ -44,11 +44,11 @@ import com.github.kr328.clash.ui.theme.TabbyThemeWrapper
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal data class EditableTextList(val title: Int, val initialValues: List<String>?) : NavKey
+internal data class EditableTextList(val title: Int, val initialValues: Set<String>?) : NavKey
 
 internal fun EntryProviderScope<NavKey>.editableTextListScreenEntry(
   onDismiss: () -> Unit,
-  onApply: (List<String>?) -> Unit,
+  onApply: (Set<String>?) -> Unit,
 ) {
   entry<EditableTextList> { key ->
     EditableTextListScreen(
@@ -63,11 +63,11 @@ internal fun EntryProviderScope<NavKey>.editableTextListScreenEntry(
 @Composable
 private fun EditableTextListScreen(
   @StringRes title: Int,
-  initialValues: List<String>?,
+  initialValues: Set<String>?,
   onDismiss: () -> Unit,
-  onApply: (List<String>?) -> Unit,
+  onApply: (Set<String>?) -> Unit,
 ) {
-  val values = remember(initialValues) { initialValues.orEmpty().toMutableStateList() }
+  val setValues = remember(initialValues) { initialValues.orEmpty().toMutableStateList() }
   var showAddDialog by remember { mutableStateOf(false) }
 
   TabbyScaffold(
@@ -83,15 +83,15 @@ private fun EditableTextListScreen(
     },
   ) { innerPadding ->
     Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
-      if (values.isEmpty()) {
+      if (setValues.isEmpty()) {
         EmptyEditorContent(Modifier.weight(1f))
       } else {
         LazyColumn(modifier = Modifier.weight(1f)) {
-          itemsIndexed(values) { index, value ->
+          itemsIndexed(setValues) { index, setValue ->
             ListItem(
-              headlineContent = { Text(value) },
+              headlineContent = { Text(setValue) },
               trailingContent = {
-                IconButton(onClick = { values.removeAt(index) }) {
+                IconButton(onClick = { setValues.removeAt(index) }) {
                   Icon(
                     imageVector = TabbyIcons.OutlineDelete,
                     contentDescription = stringResource(CommonR.string.delete),
@@ -110,7 +110,7 @@ private fun EditableTextListScreen(
       ) {
         TextButton(onClick = { onApply(null) }) { Text(stringResource(CommonR.string.reset)) }
         TextButton(onClick = onDismiss) { Text(stringResource(CommonR.string.cancel)) }
-        TextButton(onClick = { onApply(values.toList()) }) {
+        TextButton(onClick = { onApply(setValues.toSet()) }) {
           Text(stringResource(CommonR.string.ok))
         }
       }
@@ -122,8 +122,8 @@ private fun EditableTextListScreen(
       title = title,
       onDismiss = { showAddDialog = false },
       onConfirm = { newValue ->
-        if (newValue.isNotBlank()) {
-          values.add(newValue)
+        if (newValue.isNotBlank() && !setValues.contains(newValue)) {
+          setValues.add(newValue)
         }
         showAddDialog = false
       },
@@ -174,7 +174,7 @@ private fun SingleTextInputDialog(
 private fun EditableTextListScreenPreview() {
   EditableTextListScreen(
     title = R.string.sniff_http_ports,
-    initialValues = listOf("80", "8080"),
+    initialValues = setOf("80", "8080"),
     onDismiss = {},
     onApply = {},
   )

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextSetScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextSetScreen.kt
@@ -46,12 +46,12 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class EditableTextList(val title: Int, val initialValues: Set<String>?) : NavKey
 
-internal fun EntryProviderScope<NavKey>.editableTextListScreenEntry(
+internal fun EntryProviderScope<NavKey>.editableTextSetScreenEntry(
   onDismiss: () -> Unit,
   onApply: (Set<String>?) -> Unit,
 ) {
   entry<EditableTextList> { key ->
-    EditableTextListScreen(
+    EditableTextSetScreen(
       title = key.title,
       initialValues = key.initialValues,
       onDismiss = onDismiss,
@@ -61,13 +61,13 @@ internal fun EntryProviderScope<NavKey>.editableTextListScreenEntry(
 }
 
 @Composable
-private fun EditableTextListScreen(
+private fun EditableTextSetScreen(
   @StringRes title: Int,
   initialValues: Set<String>?,
   onDismiss: () -> Unit,
   onApply: (Set<String>?) -> Unit,
 ) {
-  val setValues = remember(initialValues) { initialValues.orEmpty().toMutableStateList() }
+  val values = remember(initialValues) { initialValues.orEmpty().toMutableStateList() }
   var showAddDialog by remember { mutableStateOf(false) }
 
   TabbyScaffold(
@@ -83,15 +83,15 @@ private fun EditableTextListScreen(
     },
   ) { innerPadding ->
     Column(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
-      if (setValues.isEmpty()) {
+      if (values.isEmpty()) {
         EmptyEditorContent(Modifier.weight(1f))
       } else {
         LazyColumn(modifier = Modifier.weight(1f)) {
-          itemsIndexed(setValues) { index, setValue ->
+          itemsIndexed(values) { index, value ->
             ListItem(
-              headlineContent = { Text(setValue) },
+              headlineContent = { Text(value) },
               trailingContent = {
-                IconButton(onClick = { setValues.removeAt(index) }) {
+                IconButton(onClick = { values.removeAt(index) }) {
                   Icon(
                     imageVector = TabbyIcons.OutlineDelete,
                     contentDescription = stringResource(CommonR.string.delete),
@@ -110,7 +110,7 @@ private fun EditableTextListScreen(
       ) {
         TextButton(onClick = { onApply(null) }) { Text(stringResource(CommonR.string.reset)) }
         TextButton(onClick = onDismiss) { Text(stringResource(CommonR.string.cancel)) }
-        TextButton(onClick = { onApply(setValues.toSet()) }) {
+        TextButton(onClick = { onApply(values.toSet()) }) {
           Text(stringResource(CommonR.string.ok))
         }
       }
@@ -122,8 +122,8 @@ private fun EditableTextListScreen(
       title = title,
       onDismiss = { showAddDialog = false },
       onConfirm = { newValue ->
-        if (newValue.isNotBlank() && !setValues.contains(newValue)) {
-          setValues.add(newValue)
+        if (newValue.isNotBlank() && !values.contains(newValue)) {
+          values.add(newValue)
         }
         showAddDialog = false
       },
@@ -171,8 +171,8 @@ private fun SingleTextInputDialog(
 @PreviewWrapper(TabbyThemeWrapper::class)
 @PreviewTabby
 @Composable
-private fun EditableTextListScreenPreview() {
-  EditableTextListScreen(
+private fun EditableTextSetScreenPreview() {
+  EditableTextSetScreen(
     title = R.string.sniff_http_ports,
     initialValues = setOf("80", "8080"),
     onDismiss = {},

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/MetaFeatureSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/MetaFeatureSettingsScreen.kt
@@ -152,7 +152,7 @@ internal fun MetaFeatureSettingsScreen(
             )
           }
         }
-        editableTextListScreenEntry(
+        editableTextSetScreenEntry(
           onDismiss = {
             currentEditableTextListOnApply = null
             backStack.removeLastOrNull()

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/MetaFeatureSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/MetaFeatureSettingsScreen.kt
@@ -131,7 +131,7 @@ internal fun MetaFeatureSettingsScreen(
             },
             onOpenEditableTextList = { title, initialValues, onApply ->
               currentEditableTextListOnApply = onApply
-              backStack.addIfNotLast(EditableTextList(title, initialValues))
+              backStack.addIfNotLast(EditableTextList(title, initialValues?.toSet()))
             },
           )
 
@@ -158,7 +158,7 @@ internal fun MetaFeatureSettingsScreen(
             backStack.removeLastOrNull()
           },
           onApply = { newValues ->
-            currentEditableTextListOnApply?.invoke(newValues)
+            currentEditableTextListOnApply?.invoke(newValues?.toList())
             currentEditableTextListOnApply = null
             backStack.removeLastOrNull()
           },

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/OverrideSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/OverrideSettingsScreen.kt
@@ -98,7 +98,7 @@ internal fun OverrideSettingsScreen(
             },
             onOpenEditableTextList = { title, initialValues, onApply ->
               currentEditableTextListOnApply = onApply
-              backStack.addIfNotLast(EditableTextList(title, initialValues))
+              backStack.addIfNotLast(EditableTextList(title, initialValues?.toSet()))
             },
           )
         }
@@ -119,7 +119,7 @@ internal fun OverrideSettingsScreen(
             backStack.removeLastOrNull()
           },
           onApply = { newValues ->
-            currentEditableTextListOnApply?.invoke(newValues)
+            currentEditableTextListOnApply?.invoke(newValues?.toList())
             currentEditableTextListOnApply = null
             backStack.removeLastOrNull()
           },

--- a/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/OverrideSettingsScreen.kt
+++ b/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/OverrideSettingsScreen.kt
@@ -113,7 +113,7 @@ internal fun OverrideSettingsScreen(
             backStack.removeLastOrNull()
           },
         )
-        editableTextListScreenEntry(
+        editableTextSetScreenEntry(
           onDismiss = {
             currentEditableTextListOnApply = null
             backStack.removeLastOrNull()


### PR DESCRIPTION
Aligns with https://github.com/Goooler/Tabby/blob/e7567b1d1888c4643a16fbf59cda4e1b64492ff8/ui/settings/src/main/kotlin/com/github/kr328/clash/settings/ui/EditableTextMapScreen.kt.