### PR TITLE
Move About version info to Help screen

### DIFF
--- a/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HelpScreen.kt
+++ b/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HelpScreen.kt
@@ -31,6 +31,7 @@ import com.github.kr328.clash.glue.util.openLink
 import com.github.kr328.clash.home.R
 import com.github.kr328.clash.home.vm.HelpViewModel
 import com.github.kr328.clash.ui.component.TabbyScaffold
+import com.github.kr328.clash.ui.icon.BaselineInfo
 import com.github.kr328.clash.ui.icon.BaselineUpdate
 import com.github.kr328.clash.ui.icon.OutlineInfo
 import com.github.kr328.clash.ui.icon.TabbyIcons
@@ -134,11 +135,13 @@ private fun HelpContent(
           key = "app_version",
           title = { Text(stringResource(R.string.app_version)) },
           summary = { Text(uiState.appVersion) },
+          icon = { Icon(imageVector = TabbyIcons.BaselineInfo, contentDescription = null) },
         )
         preference(
           key = "kernel_version",
           title = { Text(stringResource(R.string.kernel_version)) },
           summary = { Text(uiState.coreVersion) },
+          icon = { Icon(imageVector = TabbyIcons.BaselineInfo, contentDescription = null) },
         )
         preference(
           key = "check_for_updates",

--- a/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HelpScreen.kt
+++ b/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HelpScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.fromHtml
@@ -141,7 +142,12 @@ private fun HelpContent(
           key = "kernel_version",
           title = { Text(stringResource(R.string.kernel_version)) },
           summary = { Text(uiState.coreVersion) },
-          icon = { Icon(imageVector = TabbyIcons.BaselineInfo, contentDescription = null) },
+          icon = {
+            Icon(
+              painter = painterResource(CommonR.drawable.ic_tabby_small),
+              contentDescription = null,
+            )
+          },
         )
         preference(
           key = "check_for_updates",

--- a/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HelpScreen.kt
+++ b/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HelpScreen.kt
@@ -131,6 +131,16 @@ private fun HelpContent(
         )
         preferenceCategory(key = "cat_update", title = { Text(stringResource(R.string.about)) })
         preference(
+          key = "app_version",
+          title = { Text(stringResource(R.string.app_version)) },
+          summary = { Text(uiState.appVersion) },
+        )
+        preference(
+          key = "kernel_version",
+          title = { Text(stringResource(R.string.kernel_version)) },
+          summary = { Text(uiState.coreVersion) },
+        )
+        preference(
           key = "check_for_updates",
           title = { Text(stringResource(R.string.check_for_updates)) },
           icon = {

--- a/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HomeScreen.kt
+++ b/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HomeScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
@@ -26,7 +25,6 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -37,7 +35,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewWrapper
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -49,7 +46,6 @@ import com.github.kr328.clash.ui.component.TabbyScaffold
 import com.github.kr328.clash.ui.icon.BaselineApps
 import com.github.kr328.clash.ui.icon.BaselineAssignment
 import com.github.kr328.clash.ui.icon.BaselineHelpCenter
-import com.github.kr328.clash.ui.icon.BaselineInfo
 import com.github.kr328.clash.ui.icon.BaselineSettings
 import com.github.kr328.clash.ui.icon.BaselineSwapVerticalCircle
 import com.github.kr328.clash.ui.icon.BaselineViewList
@@ -118,8 +114,6 @@ internal fun HomeScreen(
     mode = uiState.mode,
     profileName = uiState.profileName,
     hasProviders = uiState.hasProviders,
-    aboutVersionName = uiState.aboutVersionName,
-    onDismissAbout = viewModel::dismissAbout,
     onToggleStatus = viewModel::toggleStatus,
     onOpenProxy = onOpenProxy,
     onOpenProfiles = onOpenProfiles,
@@ -127,7 +121,6 @@ internal fun HomeScreen(
     onOpenLogs = onOpenLogs,
     onOpenSettings = onOpenSettings,
     onOpenHelp = onOpenHelp,
-    onOpenAbout = viewModel::showAbout,
   )
 }
 
@@ -140,8 +133,6 @@ private fun HomeContent(
   mode: String?,
   profileName: String?,
   hasProviders: Boolean,
-  aboutVersionName: String?,
-  onDismissAbout: () -> Unit,
   onToggleStatus: () -> Unit,
   onOpenProxy: () -> Unit,
   onOpenProfiles: () -> Unit,
@@ -149,7 +140,6 @@ private fun HomeContent(
   onOpenLogs: () -> Unit,
   onOpenSettings: () -> Unit,
   onOpenHelp: () -> Unit,
-  onOpenAbout: () -> Unit,
 ) {
   val darkTheme = isSystemInDarkTheme()
   val stoppedColor = if (darkTheme) TabbyDarkSurface else TabbyLightStopped
@@ -248,15 +238,7 @@ private fun HomeContent(
         text = stringResource(R.string.help),
         onClick = onOpenHelp,
       )
-      HomeActionLabel(
-        modifier = Modifier.padding(vertical = labelMarginVertical),
-        icon = TabbyIcons.BaselineInfo,
-        text = stringResource(R.string.about),
-        onClick = onOpenAbout,
-      )
     }
-
-    aboutVersionName?.let { AboutDialog(versionName = it, onDismiss = onDismissAbout) }
   }
 }
 
@@ -323,33 +305,6 @@ private fun HomeActionLabel(
   }
 }
 
-@Composable
-private fun AboutDialog(versionName: String, onDismiss: () -> Unit) {
-  AlertDialog(
-    onDismissRequest = onDismiss,
-    confirmButton = {
-      TextButton(onClick = onDismiss) { Text(text = stringResource(CommonR.string.ok)) }
-    },
-    icon = {
-      Image(
-        painter = painterResource(CommonR.drawable.ic_tabby_foreground),
-        contentDescription = null,
-        modifier = Modifier.size(logoSize),
-      )
-    },
-    title = {
-      Text(
-        text = stringResource(CommonR.string.tabby),
-        modifier = Modifier.fillMaxWidth(),
-        textAlign = TextAlign.Center,
-      )
-    },
-    text = {
-      Text(text = versionName, modifier = Modifier.fillMaxWidth(), textAlign = TextAlign.Center)
-    },
-  )
-}
-
 private val logoSize = 55.dp
 private val cardMarginVertical = 5.dp
 private val labelMarginVertical = 2.dp
@@ -368,8 +323,6 @@ private fun HomeContentRunningPreview() {
     mode = "Rule",
     profileName = "My Profile",
     hasProviders = true,
-    aboutVersionName = null,
-    onDismissAbout = {},
     onToggleStatus = {},
     onOpenProxy = {},
     onOpenProfiles = {},
@@ -377,7 +330,6 @@ private fun HomeContentRunningPreview() {
     onOpenLogs = {},
     onOpenSettings = {},
     onOpenHelp = {},
-    onOpenAbout = {},
   )
 }
 
@@ -392,8 +344,6 @@ private fun HomeContentStoppedPreview() {
     mode = null,
     profileName = null,
     hasProviders = false,
-    aboutVersionName = null,
-    onDismissAbout = {},
     onToggleStatus = {},
     onOpenProxy = {},
     onOpenProfiles = {},
@@ -401,6 +351,5 @@ private fun HomeContentStoppedPreview() {
     onOpenLogs = {},
     onOpenSettings = {},
     onOpenHelp = {},
-    onOpenAbout = {},
   )
 }

--- a/ui/home/src/main/kotlin/com/github/kr328/clash/home/vm/HelpViewModel.kt
+++ b/ui/home/src/main/kotlin/com/github/kr328/clash/home/vm/HelpViewModel.kt
@@ -4,14 +4,18 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.application
 import androidx.lifecycle.viewModelScope
+import com.github.kr328.clash.common.R as CommonR
 import com.github.kr328.clash.common.log.Log
+import com.github.kr328.clash.core.bridge.Bridge
 import com.github.kr328.clash.glue.util.TABBY_RELEASES_LATEST
 import com.github.kr328.clash.home.R
 import com.github.kr328.clash.home.api.HelpApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import net.swiftzer.semver.SemVer
 
 internal class HelpViewModel(app: Application) : AndroidViewModel(app) {
@@ -22,6 +26,10 @@ internal class HelpViewModel(app: Application) : AndroidViewModel(app) {
 
   val eventState: StateFlow<EventState>
     field = MutableStateFlow<EventState>(EventState.Idle)
+
+  init {
+    loadVersionInfo()
+  }
 
   fun checkForUpdates() {
     if (uiState.value.checkingForUpdates) return
@@ -62,7 +70,26 @@ internal class HelpViewModel(app: Application) : AndroidViewModel(app) {
     eventState.value = EventState.Idle
   }
 
-  data class UiState(val checkingForUpdates: Boolean = false)
+  private fun loadVersionInfo() {
+    viewModelScope.launch {
+      val (appVersion, coreVersion) =
+        withContext(Dispatchers.IO) {
+          val appVersion =
+            application.packageManager.getPackageInfo(application.packageName, 0).versionName
+              ?: application.getString(CommonR.string.unknown)
+          val coreVersion = Bridge.nativeCoreVersion().replace("_", "-")
+          appVersion to coreVersion
+        }
+
+      uiState.update { it.copy(appVersion = appVersion, coreVersion = coreVersion) }
+    }
+  }
+
+  data class UiState(
+    val checkingForUpdates: Boolean = false,
+    val appVersion: String = "",
+    val coreVersion: String = "",
+  )
 
   sealed interface EventState {
     data object Idle : EventState

--- a/ui/home/src/main/kotlin/com/github/kr328/clash/home/vm/HomeViewModel.kt
+++ b/ui/home/src/main/kotlin/com/github/kr328/clash/home/vm/HomeViewModel.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.application
 import androidx.lifecycle.viewModelScope
 import com.github.kr328.clash.common.R as CommonR
 import com.github.kr328.clash.common.log.Log
-import com.github.kr328.clash.core.bridge.Bridge
 import com.github.kr328.clash.core.util.trafficTotal
 import com.github.kr328.clash.glue.remote.Remote
 import com.github.kr328.clash.glue.util.startClashService
@@ -17,7 +16,6 @@ import com.github.kr328.clash.glue.util.stopClashService
 import com.github.kr328.clash.glue.util.withClash
 import com.github.kr328.clash.glue.util.withProfile
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,7 +23,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 internal class HomeViewModel(app: Application) : AndroidViewModel(app), DefaultLifecycleObserver {
   private var broadcastEventsJob: Job? = null
@@ -75,22 +72,6 @@ internal class HomeViewModel(app: Application) : AndroidViewModel(app), DefaultL
     } else {
       startClash()
     }
-  }
-
-  fun showAbout() {
-    viewModelScope.launch {
-      val versionName =
-        withContext(Dispatchers.IO) {
-          application.packageManager.getPackageInfo(application.packageName, 0).versionName +
-            "\n" +
-            Bridge.nativeCoreVersion().replace("_", "-")
-        }
-      uiState.update { it.copy(aboutVersionName = versionName) }
-    }
-  }
-
-  fun dismissAbout() {
-    uiState.update { it.copy(aboutVersionName = null) }
   }
 
   fun onVpnPermissionGranted() {
@@ -164,7 +145,6 @@ internal class HomeViewModel(app: Application) : AndroidViewModel(app), DefaultL
     val mode: String? = null,
     val profileName: String? = null,
     val hasProviders: Boolean = false,
-    val aboutVersionName: String? = null,
   )
 
   sealed interface EventState {

--- a/ui/home/src/main/res/values-ja-rJP/strings.xml
+++ b/ui/home/src/main/res/values-ja-rJP/strings.xml
@@ -2,6 +2,7 @@
 
   <string name="about">アプリについて</string>
   <string name="already_up_to_date">最新バージョンです</string>
+  <string name="app_version">アプリバージョン</string>
   <string name="check_for_updates">アップデートを確認</string>
   <string name="check_update_failed">アップデートの確認に失敗しました</string>
   <string name="clash_meta_core">Clash Meta Core</string>
@@ -15,7 +16,6 @@
   <string name="github_issues">GitHub Issues</string>
   <string name="google_play">Google Play</string>
   <string name="help">ヘルプ</string>
-  <string name="app_version">アプリバージョン</string>
   <string name="kernel_version">コアバージョン</string>
   <string name="no_profile_selected">プロファイルが選択されていません</string>
   <string name="open">開く</string>

--- a/ui/home/src/main/res/values-ja-rJP/strings.xml
+++ b/ui/home/src/main/res/values-ja-rJP/strings.xml
@@ -15,6 +15,8 @@
   <string name="github_issues">GitHub Issues</string>
   <string name="google_play">Google Play</string>
   <string name="help">ヘルプ</string>
+  <string name="app_version">アプリバージョン</string>
+  <string name="kernel_version">コアバージョン</string>
   <string name="no_profile_selected">プロファイルが選択されていません</string>
   <string name="open">開く</string>
   <string name="profile">プロファイル</string>

--- a/ui/home/src/main/res/values-ko-rKR/strings.xml
+++ b/ui/home/src/main/res/values-ko-rKR/strings.xml
@@ -15,6 +15,8 @@
   <string name="github_issues">GitHub Issues</string>
   <string name="google_play">Google Play</string>
   <string name="help">도움</string>
+  <string name="app_version">앱 버전</string>
+  <string name="kernel_version">코어 버전</string>
   <string name="no_profile_selected">구성 파일이 선택되지 않았습니다.</string>
   <string name="open">열기</string>
   <string name="profile">구성</string>

--- a/ui/home/src/main/res/values-ko-rKR/strings.xml
+++ b/ui/home/src/main/res/values-ko-rKR/strings.xml
@@ -2,6 +2,7 @@
 
   <string name="about">정보</string>
   <string name="already_up_to_date">이미 최신 버전입니다</string>
+  <string name="app_version">앱 버전</string>
   <string name="check_for_updates">업데이트 확인</string>
   <string name="check_update_failed">업데이트 확인 실패</string>
   <string name="clash_meta_core">Clash Meta 코어</string>
@@ -15,7 +16,6 @@
   <string name="github_issues">GitHub Issues</string>
   <string name="google_play">Google Play</string>
   <string name="help">도움</string>
-  <string name="app_version">앱 버전</string>
   <string name="kernel_version">코어 버전</string>
   <string name="no_profile_selected">구성 파일이 선택되지 않았습니다.</string>
   <string name="open">열기</string>

--- a/ui/home/src/main/res/values-ru/strings.xml
+++ b/ui/home/src/main/res/values-ru/strings.xml
@@ -15,6 +15,8 @@
   <string name="github_issues">Сообщения об ошибках на GitHub</string>
   <string name="google_play">Google Play</string>
   <string name="help">Помощь</string>
+  <string name="app_version">Версия приложения</string>
+  <string name="kernel_version">Версия Core</string>
   <string name="no_profile_selected">Профиль не выбран</string>
   <string name="open">Открыть</string>
   <string name="profile">Профиль</string>
@@ -23,5 +25,6 @@
   <string name="tips_help"><![CDATA[Tabby для Android — <strong>бесплатен</strong> и мы <strong>НЕ</strong> предоставляем по нему поддержку]]></string>
   <string name="update_available">Доступна новая версия</string>
   <string name="version_updated">Приложение обновлено</string>
-  <string name="version_updated_tips">Настройки были сброшены, старые профили необходимо сохранить повторно</string>
+  <string name="version_updated_tips">Настройки были сброшены, старые профили необходимо сохранить
+    повторно</string>
 </resources>

--- a/ui/home/src/main/res/values-ru/strings.xml
+++ b/ui/home/src/main/res/values-ru/strings.xml
@@ -25,6 +25,5 @@
   <string name="tips_help"><![CDATA[Tabby для Android — <strong>бесплатен</strong> и мы <strong>НЕ</strong> предоставляем по нему поддержку]]></string>
   <string name="update_available">Доступна новая версия</string>
   <string name="version_updated">Приложение обновлено</string>
-  <string name="version_updated_tips">Настройки были сброшены, старые профили необходимо сохранить
-    повторно</string>
+  <string name="version_updated_tips">Настройки были сброшены, старые профили необходимо сохранить повторно</string>
 </resources>

--- a/ui/home/src/main/res/values-ru/strings.xml
+++ b/ui/home/src/main/res/values-ru/strings.xml
@@ -2,6 +2,7 @@
 
   <string name="about">О программе</string>
   <string name="already_up_to_date">Уже актуально</string>
+  <string name="app_version">Версия приложения</string>
   <string name="check_for_updates">Проверить обновления</string>
   <string name="check_update_failed">Не удалось проверить обновления</string>
   <string name="clash_meta_core">Ядро Clash Meta</string>
@@ -15,7 +16,6 @@
   <string name="github_issues">Сообщения об ошибках на GitHub</string>
   <string name="google_play">Google Play</string>
   <string name="help">Помощь</string>
-  <string name="app_version">Версия приложения</string>
   <string name="kernel_version">Версия Core</string>
   <string name="no_profile_selected">Профиль не выбран</string>
   <string name="open">Открыть</string>

--- a/ui/home/src/main/res/values-vi/strings.xml
+++ b/ui/home/src/main/res/values-vi/strings.xml
@@ -22,10 +22,8 @@
   <string name="profile">Cấu hình</string>
   <string name="sources">Nguồn</string>
   <string name="stopped">Đã ngắt kết nối</string>
-  <string name="tips_help">Tabby là một phần mềm miễn phí và chúng tôi KHÔNG cung cấp bất kỳ dịch vụ
-    trả phí nào cho nó</string>
+  <string name="tips_help">Tabby là một phần mềm miễn phí và chúng tôi KHÔNG cung cấp bất kỳ dịch vụ trả phí nào cho nó</string>
   <string name="update_available">Có phiên bản mới</string>
   <string name="version_updated">Đã cập nhật ứng dụng</string>
-  <string name="version_updated_tips">Các cài đặt đã được đặt lại và các cấu hình cũ cần được lưu
-    lại.</string>
+  <string name="version_updated_tips">Các cài đặt đã được đặt lại và các cấu hình cũ cần được lưu lại.</string>
 </resources>

--- a/ui/home/src/main/res/values-vi/strings.xml
+++ b/ui/home/src/main/res/values-vi/strings.xml
@@ -2,6 +2,7 @@
 
   <string name="about">Thông tin</string>
   <string name="already_up_to_date">Đã là phiên bản mới nhất</string>
+  <string name="app_version">Phiên bản ứng dụng</string>
   <string name="check_for_updates">Kiểm tra cập nhật</string>
   <string name="check_update_failed">Không thể kiểm tra cập nhật</string>
   <string name="clash_meta_core">Clash Meta Core</string>
@@ -15,7 +16,6 @@
   <string name="github_issues">Sự cố trên GitHub</string>
   <string name="google_play">Google Play</string>
   <string name="help">Trợ giúp</string>
-  <string name="app_version">Phiên bản ứng dụng</string>
   <string name="kernel_version">Phiên bản Core</string>
   <string name="no_profile_selected">Không có cấu hình</string>
   <string name="open">Mở</string>

--- a/ui/home/src/main/res/values-vi/strings.xml
+++ b/ui/home/src/main/res/values-vi/strings.xml
@@ -15,13 +15,17 @@
   <string name="github_issues">Sự cố trên GitHub</string>
   <string name="google_play">Google Play</string>
   <string name="help">Trợ giúp</string>
+  <string name="app_version">Phiên bản ứng dụng</string>
+  <string name="kernel_version">Phiên bản Core</string>
   <string name="no_profile_selected">Không có cấu hình</string>
   <string name="open">Mở</string>
   <string name="profile">Cấu hình</string>
   <string name="sources">Nguồn</string>
   <string name="stopped">Đã ngắt kết nối</string>
-  <string name="tips_help">Tabby là một phần mềm miễn phí và chúng tôi KHÔNG cung cấp bất kỳ dịch vụ trả phí nào cho nó</string>
+  <string name="tips_help">Tabby là một phần mềm miễn phí và chúng tôi KHÔNG cung cấp bất kỳ dịch vụ
+    trả phí nào cho nó</string>
   <string name="update_available">Có phiên bản mới</string>
   <string name="version_updated">Đã cập nhật ứng dụng</string>
-  <string name="version_updated_tips">Các cài đặt đã được đặt lại và các cấu hình cũ cần được lưu lại.</string>
+  <string name="version_updated_tips">Các cài đặt đã được đặt lại và các cấu hình cũ cần được lưu
+    lại.</string>
 </resources>

--- a/ui/home/src/main/res/values-zh-rHK/strings.xml
+++ b/ui/home/src/main/res/values-zh-rHK/strings.xml
@@ -2,6 +2,7 @@
 
   <string name="about">關於</string>
   <string name="already_up_to_date">已是最新版本</string>
+  <string name="app_version">應用版本</string>
   <string name="check_for_updates">檢查更新</string>
   <string name="check_update_failed">檢查更新失敗</string>
   <string name="clash_meta_core">Clash Meta 核心</string>
@@ -15,7 +16,6 @@
   <string name="github_issues">GitHub Issues</string>
   <string name="google_play">Google Play</string>
   <string name="help">幫助</string>
-  <string name="app_version">應用版本</string>
   <string name="kernel_version">核心版本</string>
   <string name="no_profile_selected">沒有選擇配置文件</string>
   <string name="open">開啟</string>

--- a/ui/home/src/main/res/values-zh-rHK/strings.xml
+++ b/ui/home/src/main/res/values-zh-rHK/strings.xml
@@ -15,6 +15,8 @@
   <string name="github_issues">GitHub Issues</string>
   <string name="google_play">Google Play</string>
   <string name="help">幫助</string>
+  <string name="app_version">應用版本</string>
+  <string name="kernel_version">核心版本</string>
   <string name="no_profile_selected">沒有選擇配置文件</string>
   <string name="open">開啟</string>
   <string name="profile">配置</string>

--- a/ui/home/src/main/res/values-zh-rTW/strings.xml
+++ b/ui/home/src/main/res/values-zh-rTW/strings.xml
@@ -2,6 +2,7 @@
 
   <string name="about">關於</string>
   <string name="already_up_to_date">已是最新版本</string>
+  <string name="app_version">應用程式版本</string>
   <string name="check_for_updates">檢查更新</string>
   <string name="check_update_failed">檢查更新失敗</string>
   <string name="clash_meta_core">Clash Meta 核心</string>
@@ -15,7 +16,6 @@
   <string name="github_issues">GitHub Issues</string>
   <string name="google_play">Google Play</string>
   <string name="help">協助</string>
-  <string name="app_version">應用程式版本</string>
   <string name="kernel_version">核心版本</string>
   <string name="no_profile_selected">未選擇設定檔</string>
   <string name="open">開啟</string>

--- a/ui/home/src/main/res/values-zh-rTW/strings.xml
+++ b/ui/home/src/main/res/values-zh-rTW/strings.xml
@@ -15,6 +15,8 @@
   <string name="github_issues">GitHub Issues</string>
   <string name="google_play">Google Play</string>
   <string name="help">協助</string>
+  <string name="app_version">應用程式版本</string>
+  <string name="kernel_version">核心版本</string>
   <string name="no_profile_selected">未選擇設定檔</string>
   <string name="open">開啟</string>
   <string name="profile">設定檔</string>

--- a/ui/home/src/main/res/values-zh/strings.xml
+++ b/ui/home/src/main/res/values-zh/strings.xml
@@ -16,7 +16,7 @@
   <string name="google_play">Google Play</string>
   <string name="help">帮助</string>
   <string name="app_version">应用版本</string>
-  <string name="kernel_version">内核版本</string>
+  <string name="kernel_version">核心版本</string>
   <string name="no_profile_selected">没有选择配置文件</string>
   <string name="open">打开</string>
   <string name="profile">配置</string>

--- a/ui/home/src/main/res/values-zh/strings.xml
+++ b/ui/home/src/main/res/values-zh/strings.xml
@@ -15,6 +15,8 @@
   <string name="github_issues">GitHub Issues</string>
   <string name="google_play">Google Play</string>
   <string name="help">帮助</string>
+  <string name="app_version">应用版本</string>
+  <string name="kernel_version">内核版本</string>
   <string name="no_profile_selected">没有选择配置文件</string>
   <string name="open">打开</string>
   <string name="profile">配置</string>

--- a/ui/home/src/main/res/values-zh/strings.xml
+++ b/ui/home/src/main/res/values-zh/strings.xml
@@ -2,6 +2,7 @@
 
   <string name="about">关于</string>
   <string name="already_up_to_date">已是最新版本</string>
+  <string name="app_version">应用版本</string>
   <string name="check_for_updates">检查更新</string>
   <string name="check_update_failed">检查更新失败</string>
   <string name="clash_meta_core">Clash Meta 核心</string>
@@ -15,7 +16,6 @@
   <string name="github_issues">GitHub Issues</string>
   <string name="google_play">Google Play</string>
   <string name="help">帮助</string>
-  <string name="app_version">应用版本</string>
   <string name="kernel_version">核心版本</string>
   <string name="no_profile_selected">没有选择配置文件</string>
   <string name="open">打开</string>

--- a/ui/home/src/main/res/values/strings.xml
+++ b/ui/home/src/main/res/values/strings.xml
@@ -15,6 +15,8 @@
   <string name="github_issues">GitHub Issues</string>
   <string name="google_play">Google Play</string>
   <string name="help">Help</string>
+  <string name="app_version">App Version</string>
+  <string name="kernel_version">Kernel Version</string>
   <string name="no_profile_selected">No profile selected</string>
   <string name="open">Open</string>
   <string name="profile">Profile</string>
@@ -23,5 +25,6 @@
   <string name="tips_help"><![CDATA[Tabby is a <strong>freeware</strong> and we do <strong>NOT</strong> provide any service for it]]></string>
   <string name="update_available">A new version is available</string>
   <string name="version_updated">App Updated</string>
-  <string name="version_updated_tips">The settings have been rested and the old profiles needs to be saved again.</string>
+  <string name="version_updated_tips">The settings have been rested and the old profiles needs to be
+    saved again.</string>
 </resources>

--- a/ui/home/src/main/res/values/strings.xml
+++ b/ui/home/src/main/res/values/strings.xml
@@ -25,6 +25,5 @@
   <string name="tips_help"><![CDATA[Tabby is a <strong>freeware</strong> and we do <strong>NOT</strong> provide any service for it]]></string>
   <string name="update_available">A new version is available</string>
   <string name="version_updated">App Updated</string>
-  <string name="version_updated_tips">The settings have been rested and the old profiles needs to be
-    saved again.</string>
+  <string name="version_updated_tips">The settings have been rested and the old profiles needs to be saved again.</string>
 </resources>

--- a/ui/home/src/main/res/values/strings.xml
+++ b/ui/home/src/main/res/values/strings.xml
@@ -16,7 +16,7 @@
   <string name="google_play">Google Play</string>
   <string name="help">Help</string>
   <string name="app_version">App Version</string>
-  <string name="kernel_version">Kernel Version</string>
+  <string name="kernel_version">Core Version</string>
   <string name="no_profile_selected">No profile selected</string>
   <string name="open">Open</string>
   <string name="profile">Profile</string>

--- a/ui/home/src/main/res/values/strings.xml
+++ b/ui/home/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 
   <string name="about">About</string>
   <string name="already_up_to_date">Already up to date</string>
+  <string name="app_version">App Version</string>
   <string name="check_for_updates">Check for Updates</string>
   <string name="check_update_failed">Failed to check for updates</string>
   <string name="clash_meta_core">Clash Meta Core</string>
@@ -15,7 +16,6 @@
   <string name="github_issues">GitHub Issues</string>
   <string name="google_play">Google Play</string>
   <string name="help">Help</string>
-  <string name="app_version">App Version</string>
   <string name="kernel_version">Core Version</string>
   <string name="no_profile_selected">No profile selected</string>
   <string name="open">Open</string>


### PR DESCRIPTION
## Summary
- remove the standalone About dialog and its Home-screen entry
- show version information directly in Help > About as two separate items:
  - App Version
  - Core Version
- load app/core version data in `HelpViewModel` and expose it to `HelpScreen`
- keep version rows using the info icon style in Help
- add/complete localized strings for the new labels across existing home module locales

## Why
This simplifies the Home UI and consolidates About/version details in a single place while clearly distinguishing app version from core version.

## Notes for reviewers
- Build and formatting are green (`spotlessApply`, `app:assembleDebug`).
- Branch includes only home/help UI + localization changes.