### PR TITLE
Prefer the small icon for monochrome

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,5 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
   <background android:drawable="@color/ic_launcher_background" />
   <foreground android:drawable="@mipmap/ic_launcher_foreground" />
-  <monochrome android:drawable="@mipmap/ic_launcher_foreground" />
+  <monochrome android:drawable="@drawable/ic_tabby_small" />
 </adaptive-icon>


### PR DESCRIPTION
> User theming: starting with Android 13 (API level 33), users can theme their adaptive icons. If a user enables themed app icons in their system settings, and the launcher supports this feature, the system uses the coloring of the user's chosen wallpaper and theme to determine the tint color of the app icons for apps that have a monochrome layer in their adaptive icon. Starting with Android 16 QPR 2, Android automatically themes app icons for apps that don't provide their own.

https://developer.android.com/develop/ui/compose/system/icon_design_adaptive