### PR TITLE
Resolve start/stop toggle state race conditions on HomeScreen

### DIFF
--- a/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HomeScreen.kt
+++ b/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HomeScreen.kt
@@ -81,10 +81,9 @@ internal fun HomeScreen(
 
   val vpnLauncher =
     rememberLauncherForActivityResult(StartActivityForResult()) { result ->
-      if (result.resultCode == Activity.RESULT_OK) {
-        viewModel.onVpnPermissionGranted()
-      } else {
-        viewModel.onVpnPermissionDenied()
+      when (result.resultCode) {
+        Activity.RESULT_OK -> viewModel.onVpnPermissionGranted()
+        else -> viewModel.onVpnPermissionDenied()
       }
     }
 
@@ -182,41 +181,35 @@ private fun HomeContent(
       HomeActionCard(
         modifier = Modifier.padding(vertical = cardMarginVertical),
         icon =
-          if (isTransitioning) {
-            TabbyIcons.BaselineSync
-          } else if (clashRunning) {
-            TabbyIcons.OutlineCheckCircle
-          } else {
-            TabbyIcons.OutlineNotInterested
+          when {
+            isTransitioning -> TabbyIcons.BaselineSync
+            clashRunning -> TabbyIcons.OutlineCheckCircle
+            else -> TabbyIcons.OutlineNotInterested
           },
         text =
-          if (isTransitioning) {
-            stringResource(CommonR.string.loading)
-          } else {
-            stringResource(if (clashRunning) CommonR.string.running else R.string.stopped)
+          when {
+            isTransitioning -> stringResource(CommonR.string.loading)
+            clashRunning -> stringResource(CommonR.string.running)
+            else -> stringResource(R.string.stopped)
           },
         subtext =
-          if (isTransitioning) {
-            null
-          } else if (clashRunning && forwarded != null) {
-            stringResource(R.string.format_traffic_forwarded, forwarded)
-          } else {
-            stringResource(CommonR.string.tap_to_start)
+          when {
+            isTransitioning -> null
+            clashRunning && forwarded != null ->
+              stringResource(R.string.format_traffic_forwarded, forwarded)
+            else -> stringResource(CommonR.string.tap_to_start)
           },
         backgroundColor =
-          if (isTransitioning) {
-            stoppedColor
-          } else if (clashRunning) {
-            MaterialTheme.colorScheme.primary
-          } else {
-            stoppedColor
+          when {
+            isTransitioning -> stoppedColor
+            clashRunning -> MaterialTheme.colorScheme.primary
+            else -> stoppedColor
           },
         contentColor = TabbyOnPrimary,
         onClick =
-          if (isTransitioning) {
-            {}
-          } else {
-            onToggleStatus
+          when {
+            isTransitioning -> ({})
+            else -> onToggleStatus
           },
       )
 

--- a/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HomeScreen.kt
+++ b/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HomeScreen.kt
@@ -206,11 +206,8 @@ private fun HomeContent(
             else -> stoppedColor
           },
         contentColor = TabbyOnPrimary,
-        onClick =
-          when {
-            isTransitioning -> ({})
-            else -> onToggleStatus
-          },
+        onClick = onToggleStatus,
+        enabled = !isTransitioning,
       )
 
       AnimatedVisibility(visible = clashRunning) {
@@ -277,11 +274,19 @@ private fun HomeActionCard(
   contentColor: Color,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
+  enabled: Boolean = true,
 ) {
   Card(
     modifier = modifier.fillMaxWidth().heightIn(min = 85.dp),
     onClick = onClick,
-    colors = CardDefaults.cardColors(containerColor = backgroundColor, contentColor = contentColor),
+    enabled = enabled,
+    colors =
+      CardDefaults.cardColors(
+        containerColor = backgroundColor,
+        contentColor = contentColor,
+        disabledContainerColor = backgroundColor,
+        disabledContentColor = contentColor,
+      ),
     elevation = CardDefaults.cardElevation(defaultElevation = 5.dp),
   ) {
     Row(

--- a/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HomeScreen.kt
+++ b/ui/home/src/main/kotlin/com/github/kr328/clash/home/ui/HomeScreen.kt
@@ -48,6 +48,7 @@ import com.github.kr328.clash.ui.icon.BaselineAssignment
 import com.github.kr328.clash.ui.icon.BaselineHelpCenter
 import com.github.kr328.clash.ui.icon.BaselineSettings
 import com.github.kr328.clash.ui.icon.BaselineSwapVerticalCircle
+import com.github.kr328.clash.ui.icon.BaselineSync
 import com.github.kr328.clash.ui.icon.BaselineViewList
 import com.github.kr328.clash.ui.icon.OutlineCheckCircle
 import com.github.kr328.clash.ui.icon.OutlineNotInterested
@@ -82,6 +83,8 @@ internal fun HomeScreen(
     rememberLauncherForActivityResult(StartActivityForResult()) { result ->
       if (result.resultCode == Activity.RESULT_OK) {
         viewModel.onVpnPermissionGranted()
+      } else {
+        viewModel.onVpnPermissionDenied()
       }
     }
 
@@ -114,6 +117,7 @@ internal fun HomeScreen(
     mode = uiState.mode,
     profileName = uiState.profileName,
     hasProviders = uiState.hasProviders,
+    isTransitioning = uiState.isTransitioning,
     onToggleStatus = viewModel::toggleStatus,
     onOpenProxy = onOpenProxy,
     onOpenProfiles = onOpenProfiles,
@@ -133,6 +137,7 @@ private fun HomeContent(
   mode: String?,
   profileName: String?,
   hasProviders: Boolean,
+  isTransitioning: Boolean,
   onToggleStatus: () -> Unit,
   onOpenProxy: () -> Unit,
   onOpenProfiles: () -> Unit,
@@ -176,15 +181,43 @@ private fun HomeContent(
 
       HomeActionCard(
         modifier = Modifier.padding(vertical = cardMarginVertical),
-        icon = if (clashRunning) TabbyIcons.OutlineCheckCircle else TabbyIcons.OutlineNotInterested,
-        text = stringResource(if (clashRunning) CommonR.string.running else R.string.stopped),
+        icon =
+          if (isTransitioning) {
+            TabbyIcons.BaselineSync
+          } else if (clashRunning) {
+            TabbyIcons.OutlineCheckCircle
+          } else {
+            TabbyIcons.OutlineNotInterested
+          },
+        text =
+          if (isTransitioning) {
+            stringResource(CommonR.string.loading)
+          } else {
+            stringResource(if (clashRunning) CommonR.string.running else R.string.stopped)
+          },
         subtext =
-          if (clashRunning && forwarded != null)
+          if (isTransitioning) {
+            null
+          } else if (clashRunning && forwarded != null) {
             stringResource(R.string.format_traffic_forwarded, forwarded)
-          else stringResource(CommonR.string.tap_to_start),
-        backgroundColor = if (clashRunning) MaterialTheme.colorScheme.primary else stoppedColor,
+          } else {
+            stringResource(CommonR.string.tap_to_start)
+          },
+        backgroundColor =
+          if (isTransitioning) {
+            stoppedColor
+          } else if (clashRunning) {
+            MaterialTheme.colorScheme.primary
+          } else {
+            stoppedColor
+          },
         contentColor = TabbyOnPrimary,
-        onClick = onToggleStatus,
+        onClick =
+          if (isTransitioning) {
+            {}
+          } else {
+            onToggleStatus
+          },
       )
 
       AnimatedVisibility(visible = clashRunning) {
@@ -322,6 +355,7 @@ private fun HomeContentRunningPreview() {
     mode = "Rule",
     profileName = "My Profile",
     hasProviders = true,
+    isTransitioning = false,
     onToggleStatus = {},
     onOpenProxy = {},
     onOpenProfiles = {},
@@ -343,6 +377,7 @@ private fun HomeContentStoppedPreview() {
     mode = null,
     profileName = null,
     hasProviders = false,
+    isTransitioning = false,
     onToggleStatus = {},
     onOpenProxy = {},
     onOpenProfiles = {},

--- a/ui/home/src/main/kotlin/com/github/kr328/clash/home/vm/HomeViewModel.kt
+++ b/ui/home/src/main/kotlin/com/github/kr328/clash/home/vm/HomeViewModel.kt
@@ -35,6 +35,7 @@ internal class HomeViewModel(private val dependencies: Dependencies) :
   private var fetchJob: Job? = null
   private var clashRunningJob: Job? = null
   private var transitionTimeoutJob: Job? = null
+  private var lastClashRunning: Boolean? = null
 
   val clashRunning: StateFlow<Boolean> = dependencies.clashRunning
 
@@ -47,10 +48,17 @@ internal class HomeViewModel(private val dependencies: Dependencies) :
   override fun onStart(owner: LifecycleOwner) {
     clashRunningJob?.cancel()
     clashRunningJob = viewModelScope.launch {
-      dependencies.clashRunning.collect {
-        uiState.update { it.copy(isTransitioning = false) }
-        cancelTransitionTimeout()
+      dependencies.clashRunning.collect { running ->
+        val last = lastClashRunning
+        lastClashRunning = running
+        if (last != null && last != running) {
+          uiState.update { it.copy(isTransitioning = false) }
+          cancelTransitionTimeout()
+        }
       }
+    }
+    if (uiState.value.isTransitioning) {
+      startTransitionTimeout()
     }
     broadcastEventsJob?.cancel()
     broadcastEventsJob = viewModelScope.launch {

--- a/ui/home/src/main/kotlin/com/github/kr328/clash/home/vm/HomeViewModel.kt
+++ b/ui/home/src/main/kotlin/com/github/kr328/clash/home/vm/HomeViewModel.kt
@@ -97,10 +97,9 @@ internal class HomeViewModel(private val dependencies: Dependencies) :
     uiState.update { it.copy(isTransitioning = true) }
     startTransitionTimeout()
 
-    if (clashRunning.value) {
-      dependencies.stopClashService()
-    } else {
-      startClash()
+    when (clashRunning.value) {
+      true -> dependencies.stopClashService()
+      false -> startClash()
     }
   }
 

--- a/ui/home/src/main/kotlin/com/github/kr328/clash/home/vm/HomeViewModel.kt
+++ b/ui/home/src/main/kotlin/com/github/kr328/clash/home/vm/HomeViewModel.kt
@@ -33,6 +33,8 @@ internal class HomeViewModel(private val dependencies: Dependencies) :
   private var profileLoadedJob: Job? = null
   private var trafficPollingJob: Job? = null
   private var fetchJob: Job? = null
+  private var clashRunningJob: Job? = null
+  private var transitionTimeoutJob: Job? = null
 
   val clashRunning: StateFlow<Boolean> = dependencies.clashRunning
 
@@ -43,6 +45,13 @@ internal class HomeViewModel(private val dependencies: Dependencies) :
     field = MutableStateFlow<EventState>(EventState.Idle)
 
   override fun onStart(owner: LifecycleOwner) {
+    clashRunningJob?.cancel()
+    clashRunningJob = viewModelScope.launch {
+      dependencies.clashRunning.collect {
+        uiState.update { it.copy(isTransitioning = false) }
+        cancelTransitionTimeout()
+      }
+    }
     broadcastEventsJob?.cancel()
     broadcastEventsJob = viewModelScope.launch {
       dependencies.events.collect { event ->
@@ -71,6 +80,9 @@ internal class HomeViewModel(private val dependencies: Dependencies) :
   }
 
   override fun onStop(owner: LifecycleOwner) {
+    clashRunningJob?.cancel()
+    clashRunningJob = null
+    cancelTransitionTimeout()
     broadcastEventsJob?.cancel()
     broadcastEventsJob = null
     profileLoadedJob?.cancel()
@@ -80,6 +92,11 @@ internal class HomeViewModel(private val dependencies: Dependencies) :
   }
 
   fun toggleStatus() {
+    if (uiState.value.isTransitioning) return
+
+    uiState.update { it.copy(isTransitioning = true) }
+    startTransitionTimeout()
+
     if (clashRunning.value) {
       dependencies.stopClashService()
     } else {
@@ -89,6 +106,11 @@ internal class HomeViewModel(private val dependencies: Dependencies) :
 
   fun onVpnPermissionGranted() {
     dependencies.startClashService()
+  }
+
+  fun onVpnPermissionDenied() {
+    uiState.update { it.copy(isTransitioning = false) }
+    cancelTransitionTimeout()
   }
 
   fun consumeEvent() {
@@ -161,6 +183,8 @@ internal class HomeViewModel(private val dependencies: Dependencies) :
     viewModelScope.launch {
       if (!dependencies.hasImportedActiveProfile()) {
         eventState.value = EventState.ShowNoProfileMessage
+        uiState.update { it.copy(isTransitioning = false) }
+        cancelTransitionTimeout()
         return@launch
       }
 
@@ -172,8 +196,23 @@ internal class HomeViewModel(private val dependencies: Dependencies) :
       } catch (e: Exception) {
         Log.e("Start clash service failed: ${e.message}", e)
         eventState.value = EventState.ShowMessage(dependencies.unableToStartVpnText())
+        uiState.update { it.copy(isTransitioning = false) }
+        cancelTransitionTimeout()
       }
     }
+  }
+
+  private fun startTransitionTimeout() {
+    transitionTimeoutJob?.cancel()
+    transitionTimeoutJob = viewModelScope.launch {
+      delay(10.seconds)
+      uiState.update { it.copy(isTransitioning = false) }
+    }
+  }
+
+  private fun cancelTransitionTimeout() {
+    transitionTimeoutJob?.cancel()
+    transitionTimeoutJob = null
   }
 
   data class UiState(
@@ -181,6 +220,7 @@ internal class HomeViewModel(private val dependencies: Dependencies) :
     val mode: String? = null,
     val profileName: String? = null,
     val hasProviders: Boolean = false,
+    val isTransitioning: Boolean = false,
   )
 
   sealed interface EventState {

--- a/ui/home/src/test/kotlin/com/github/kr328/clash/home/vm/HomeViewModelTest.kt
+++ b/ui/home/src/test/kotlin/com/github/kr328/clash/home/vm/HomeViewModelTest.kt
@@ -111,6 +111,43 @@ class HomeViewModelTest : KoinComponent {
     }
   }
 
+  @Test
+  fun toggleStatus_whenToggled_thenTransitionStateIsCorrect() = runTest {
+    try {
+      viewModel.onStart(UnusedLifecycleOwner)
+
+      // Initial state: not running, not transitioning
+      assertThat(viewModel.clashRunning.value).isEqualTo(false)
+      assertThat(viewModel.uiState.value.isTransitioning).isEqualTo(false)
+
+      // Act: Click toggle to start
+      viewModel.toggleStatus()
+
+      // Assert: transitions to true
+      assertThat(viewModel.uiState.value.isTransitioning).isEqualTo(true)
+
+      // Act: clash service starts
+      dependencies.clashRunning.value = true
+
+      // Assert: transitions to false
+      assertThat(viewModel.uiState.value.isTransitioning).isEqualTo(false)
+
+      // Act: Click toggle to stop
+      viewModel.toggleStatus()
+
+      // Assert: transitions to true
+      assertThat(viewModel.uiState.value.isTransitioning).isEqualTo(true)
+
+      // Act: clash service stops
+      dependencies.clashRunning.value = false
+
+      // Assert: transitions to false
+      assertThat(viewModel.uiState.value.isTransitioning).isEqualTo(false)
+    } finally {
+      viewModel.onStop(UnusedLifecycleOwner)
+    }
+  }
+
   private object UnusedLifecycleOwner : LifecycleOwner {
     override val lifecycle = LifecycleRegistry(this)
   }

--- a/ui/home/src/test/kotlin/com/github/kr328/clash/home/vm/HomeViewModelTest.kt
+++ b/ui/home/src/test/kotlin/com/github/kr328/clash/home/vm/HomeViewModelTest.kt
@@ -148,6 +148,36 @@ class HomeViewModelTest : KoinComponent {
     }
   }
 
+  @Test
+  fun toggleStatus_whenToggledAndLifecycleRestarts_thenTransitionStateIsRetained() = runTest {
+    try {
+      viewModel.onStart(UnusedLifecycleOwner)
+
+      // Act: Click toggle to start
+      viewModel.toggleStatus()
+
+      // Assert: transitions to true
+      assertThat(viewModel.uiState.value.isTransitioning).isEqualTo(true)
+
+      // Act: lifecycle stops (e.g. going to permission activity or background)
+      viewModel.onStop(UnusedLifecycleOwner)
+
+      // Act: lifecycle starts again (resuming)
+      viewModel.onStart(UnusedLifecycleOwner)
+
+      // Assert: transition state is retained, not cleared by initial emission
+      assertThat(viewModel.uiState.value.isTransitioning).isEqualTo(true)
+
+      // Act: clash service starts
+      dependencies.clashRunning.value = true
+
+      // Assert: transitions to false
+      assertThat(viewModel.uiState.value.isTransitioning).isEqualTo(false)
+    } finally {
+      viewModel.onStop(UnusedLifecycleOwner)
+    }
+  }
+
   private object UnusedLifecycleOwner : LifecycleOwner {
     override val lifecycle = LifecycleRegistry(this)
   }


### PR DESCRIPTION
This PR resolves the issue where the start/stop status card toggling on the HomeScreen doesn't always take effect or can be clicked repeatedly, leading to race conditions in the background service.

### Changes:
1. Introduced `isTransitioning` in `HomeViewModel`'s `UiState` to disable toggle button clicking and display a Loading state (with `TabbyIcons.BaselineSync` and `CommonR.string.loading`) when start/stop is in progress.
2. Refactored the control flow logic using Kotlin's idiomatic `when` expression syntax.
3. Added a 10s timeout safety net to auto-reset transition state if the service fails to start or get destroyed.
4. Handled VPN permission request cancellations to reset the transition state immediately.
5. Added unit tests verifying `isTransitioning` flow.